### PR TITLE
workaround SDK container bug for multi-RID publish in advanced scenarios, and startup permissions

### DIFF
--- a/SolisManager/SolisManager.csproj
+++ b/SolisManager/SolisManager.csproj
@@ -18,7 +18,13 @@
       <ContainerRepository>webreaper/solisagilemanager</ContainerRepository>
       <ContainerImageTag>alpha</ContainerImageTag>
       <ContainerAppCommandArgs>/appdata</ContainerAppCommandArgs>
+      <ContainerWorkingDirectory>/app/</ContainerWorkingDirectory>
     </PropertyGroup>
+
+    <ItemGroup>
+        <!-- workaround bugs in SDK container property inference (https://github.com/dotnet/sdk-container-builds/issues/623) by hard-coding -->
+        <ContainerAppCommand Include="$(ContainerWorkingDirectory)$(AssemblyName)$(_NativeExecutableExtension)" />
+    </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="Octokit" />

--- a/SolisManager/SolisManager.csproj
+++ b/SolisManager/SolisManager.csproj
@@ -17,11 +17,15 @@
       <ContainerRegistry>docker.io</ContainerRegistry>
       <ContainerRepository>webreaper/solisagilemanager</ContainerRepository>
       <ContainerImageTag>alpha</ContainerImageTag>
-      <ContainerAppCommandArgs>/appdata</ContainerAppCommandArgs>
       <ContainerWorkingDirectory>/app/</ContainerWorkingDirectory>
+      <!-- The default user for SDK-created containers is an app-local user that can only write to its HOME directory.
+           Because this app wants to write config to /appdata by default we need to change that back to the Docker-default
+           behavior of using the root user. -->
+      <ContainerUser>root</ContainerUser>
     </PropertyGroup>
 
     <ItemGroup>
+        <ContainerAppCommandArgs Include="/appdata" />
         <!-- workaround bugs in SDK container property inference (https://github.com/dotnet/sdk-container-builds/issues/623) by hard-coding -->
         <ContainerAppCommand Include="$(ContainerWorkingDirectory)$(AssemblyName)$(_NativeExecutableExtension)" />
     </ItemGroup>


### PR DESCRIPTION
This fixes the startup command for the new containers - however we're not done yet:

```
>docker run --rm -it webreaper/solisagilemanager:alpha
Creating log folder config
Unable to initialise logs: System.UnauthorizedAccessException: Access to the path '/app/config' is denied.
 ---> System.IO.IOException: Permission denied
   --- End of inner exception stack trace ---
   at System.IO.FileSystem.CreateDirectory(String fullPath, UnixFileMode unixCreateMode)
   at System.IO.Directory.CreateDirectory(String path)
   at SolisManager.Program.InitLogConfiguration(LoggerConfiguration config, String logFolder) in E:\Code\Scratch\SolisAgileManager\SolisManager\Program.cs:line 293
```

The SDK containers are created in a fairly locked down mode, where the default user isn't able to write to the app directory. So we also tell the SDK to relax a bit and allow root user usage.

