### PR TITLE
Increase Max Charge Rate limit to 125 Amps

### DIFF
--- a/SolisManager.Client/InverterConfigs/SolisInverterConfig.razor
+++ b/SolisManager.Client/InverterConfigs/SolisInverterConfig.razor
@@ -12,7 +12,7 @@
                   Immediate="true" Variant="UIConstants.MudVariant"/>
     <ConfigSettingHelp HelpText="Specifies the maximum charge and discharge rate in Amps">
         <MudNumericField T="int" Label="Max Charge Rate (Amps)" @bind-Value="@config.MaxChargeRateAmps"  @bind-Value:after="ConfigChanged"
-                         Min="5" Max="95" Variant="UIConstants.MudVariant" class="wrapped-field"/>
+                         Min="5" Max="125" Variant="UIConstants.MudVariant" class="wrapped-field"/>
     </ConfigSettingHelp>
 }
 


### PR DESCRIPTION
Many inverters can support a higher charge rate than 95 amps.